### PR TITLE
Fix state assembly constituencies

### DIFF
--- a/boundaries/build/index.json
+++ b/boundaries/build/index.json
@@ -174,7 +174,7 @@
       "lang:en": "NAME"
     },
     "filter": {
-      "match": "country:au/state:act",
+      "match": "country:au/territory:act",
       "column": "MS_FB_PARE"
     }
   },
@@ -208,7 +208,7 @@
       "lang:en": "NAME"
     },
     "filter": {
-      "match": "country:au/state:nt",
+      "match": "country:au/territory:nt",
       "column": "MS_FB_PARE"
     }
   },

--- a/boundaries/build/index.json
+++ b/boundaries/build/index.json
@@ -12,7 +12,7 @@
       "lang:en": "NAME"
     }
   },
-    {
+  {
     "directory": "states",
     "area_type_wikidata_item_id": "Q5852411",
     "associations": [
@@ -157,7 +157,7 @@
         "position_item_id": "Q18912794"
       }
     ],
-        "name_columns": {
+    "name_columns": {
       "lang:en": "NAME"
     }
   },
@@ -894,7 +894,7 @@
     "associations": [
       {
         "comment": "lord mayor of brisbane",
-        "position_item_id": "Q56477662"
+        "position_item_id": "Q29467089"
       }
     ],
     "name_columns": {

--- a/boundaries/build/position-data-query-results.json
+++ b/boundaries/build/position-data-query-results.json
@@ -8641,6 +8641,10 @@
         "type" : "literal",
         "value" : "member of Town of East Fremantle Council"
       },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
       "adminAreaTypes" : {
         "type" : "literal",
         "value" : "Q24238356"
@@ -8671,10 +8675,6 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Town of East Fremantle Council"
-      },
-      "positionType" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4175034"
       }
     }, {
       "position" : {
@@ -8727,6 +8727,10 @@
         "type" : "literal",
         "value" : "member of Town of Cambridge Council"
       },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
       "adminAreaTypes" : {
         "type" : "literal",
         "value" : "Q24238356"
@@ -8757,10 +8761,6 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Town of Cambridge Council"
-      },
-      "positionType" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4175034"
       }
     }, {
       "position" : {
@@ -8813,6 +8813,10 @@
         "type" : "literal",
         "value" : "member of Joondalup City Council"
       },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
       "adminAreaTypes" : {
         "type" : "literal",
         "value" : "Q24238356"
@@ -8843,10 +8847,6 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Joondalup City Council"
-      },
-      "positionType" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4175034"
       }
     }, {
       "position" : {
@@ -8899,6 +8899,10 @@
         "type" : "literal",
         "value" : "member of Subiaco City Council"
       },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
       "adminAreaTypes" : {
         "type" : "literal",
         "value" : "Q24238356"
@@ -8929,10 +8933,6 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Subiaco City Council"
-      },
-      "positionType" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4175034"
       }
     }, {
       "position" : {
@@ -8985,6 +8985,10 @@
         "type" : "literal",
         "value" : "member of Shire of Peppermint Grove Council"
       },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
       "adminAreaTypes" : {
         "type" : "literal",
         "value" : "Q24238356"
@@ -9015,10 +9019,6 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Shire of Peppermint Grove Council"
-      },
-      "positionType" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4175034"
       }
     }, {
       "position" : {
@@ -9071,6 +9071,10 @@
         "type" : "literal",
         "value" : "member of Town of Mosman Park Council"
       },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
       "adminAreaTypes" : {
         "type" : "literal",
         "value" : "Q24238356"
@@ -9101,10 +9105,6 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Town of Mosman Park Council"
-      },
-      "positionType" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4175034"
       }
     }, {
       "position" : {
@@ -9157,6 +9157,10 @@
         "type" : "literal",
         "value" : "member of Town of Cottesloe Council"
       },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
       "adminAreaTypes" : {
         "type" : "literal",
         "value" : "Q24238356"
@@ -9187,10 +9191,6 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Town of Cottesloe Council"
-      },
-      "positionType" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4175034"
       }
     }, {
       "position" : {
@@ -9243,6 +9243,10 @@
         "type" : "literal",
         "value" : "member of Town of Bassendean Council"
       },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
       "adminAreaTypes" : {
         "type" : "literal",
         "value" : "Q24238356"
@@ -9273,10 +9277,6 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Town of Bassendean Council"
-      },
-      "positionType" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4175034"
       }
     }, {
       "position" : {
@@ -9329,6 +9329,10 @@
         "type" : "literal",
         "value" : "member of Fremantle City Council"
       },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
       "adminAreaTypes" : {
         "type" : "literal",
         "value" : "Q24238356"
@@ -9359,10 +9363,6 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Fremantle City Council"
-      },
-      "positionType" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4175034"
       }
     }, {
       "position" : {
@@ -9415,6 +9415,10 @@
         "type" : "literal",
         "value" : "member of Perth City Council"
       },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
       "adminAreaTypes" : {
         "type" : "literal",
         "value" : "Q24238356"
@@ -9445,10 +9449,6 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Perth City Council"
-      },
-      "positionType" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4175034"
       }
     }, {
       "position" : {
@@ -9501,6 +9501,10 @@
         "type" : "literal",
         "value" : "member of Kwinana City Council"
       },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
       "adminAreaTypes" : {
         "type" : "literal",
         "value" : "Q24238356"
@@ -9531,10 +9535,6 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Kwinana City Council"
-      },
-      "positionType" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4175034"
       }
     }, {
       "position" : {
@@ -9587,6 +9587,10 @@
         "type" : "literal",
         "value" : "member of Kalamunda City Council"
       },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
       "adminAreaTypes" : {
         "type" : "literal",
         "value" : "Q24238356"
@@ -9617,10 +9621,6 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Kalamunda City Council"
-      },
-      "positionType" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4175034"
       }
     }, {
       "position" : {
@@ -9673,6 +9673,10 @@
         "type" : "literal",
         "value" : "member of the Australian Capital Territory Legislative Assembly"
       },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
       "adminAreaTypes" : {
         "type" : "literal",
         "value" : "Q10864048"
@@ -9703,10 +9707,6 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Australian Capital Territory Legislative Assembly"
-      },
-      "positionType" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4175034"
       }
     }, {
       "position" : {
@@ -9717,6 +9717,10 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Member of the Australian Senate"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
       },
       "adminAreaTypes" : {
         "type" : "literal",
@@ -9748,10 +9752,6 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Senate of Australia"
-      },
-      "positionType" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q4175034"
       }
     } ]
   }

--- a/boundaries/build/state-assembly-electoral-divisions/state-assembly-electoral-divisions.csv
+++ b/boundaries/build/state-assembly-electoral-divisions/state-assembly-electoral-divisions.csv
@@ -106,7 +106,7 @@ NT1000067,Casuarina,Q5356204,2016/05/19,Legislative Assembly,country:au/territor
 NT1000068,Namatjira,Q5356237,2016/05/19,Legislative Assembly,country:au/territory:nt,country:au/territory:nt/slaed:nt1000068
 NT1000069,Arafura,Q5356195,2016/05/19,Legislative Assembly,country:au/territory:nt,country:au/territory:nt/slaed:nt1000069
 NT1000070,Brennan,Q5356202,2016/05/19,Legislative Assembly,country:au/territory:nt,country:au/territory:nt/slaed:nt1000070
-NT1000071,Goyder,Q5355467,2016/05/19,Legislative Assembly,country:au/territory:nt,country:au/territory:nt/slaed:nt1000071
+NT1000071,Goyder,Q5356218,2016/05/19,Legislative Assembly,country:au/territory:nt,country:au/territory:nt/slaed:nt1000071
 NT1000072,Nightcliff,Q5356242,2016/05/19,Legislative Assembly,country:au/territory:nt,country:au/territory:nt/slaed:nt1000072
 NT1000073,Daly,Q5356206,2016/05/19,Legislative Assembly,country:au/territory:nt,country:au/territory:nt/slaed:nt1000073
 NT1000074,Johnston,Q5356223,2016/05/19,Legislative Assembly,country:au/territory:nt,country:au/territory:nt/slaed:nt1000074
@@ -118,7 +118,7 @@ NT1000079,Fong Lim,Q5356215,2016/05/19,Legislative Assembly,country:au/territory
 NT1000080,Barkly,Q5356198,2016/05/19,Legislative Assembly,country:au/territory:nt,country:au/territory:nt/slaed:nt1000080
 NT1000081,Nhulunbuy,Q5356241,2016/05/19,Legislative Assembly,country:au/territory:nt,country:au/territory:nt/slaed:nt1000081
 NT1000082,Sanderson,Q5356251,2016/05/19,Legislative Assembly,country:au/territory:nt,country:au/territory:nt/slaed:nt1000082
-NT1000083,Stuart,Q5355986,2016/05/19,Legislative Assembly,country:au/territory:nt,country:au/territory:nt/slaed:nt1000083
+NT1000083,Stuart,Q5356252,2016/05/19,Legislative Assembly,country:au/territory:nt,country:au/territory:nt/slaed:nt1000083
 NT1000084,Port Darwin,Q5356246,2016/05/19,Legislative Assembly,country:au/territory:nt,country:au/territory:nt/slaed:nt1000084
 NT1000085,Wanguri,Q5356258,2016/05/19,Legislative Assembly,country:au/territory:nt,country:au/territory:nt/slaed:nt1000085
 NT1000086,Spillett,Q26267294,2016/09/21,Legislative Assembly,country:au/territory:nt,country:au/territory:nt/slaed:nt1000086
@@ -157,7 +157,7 @@ QLD226,Hervey Bay,Q5355510,2017/08/09,Legislative Assembly,country:au/state:qld,
 QLD227,Hill,Q30641934,2017/08/09,Legislative Assembly,country:au/state:qld,country:au/state:qld/slaed:qld227
 QLD228,Hinchinbrook,Q5355515,2017/08/09,Legislative Assembly,country:au/state:qld,country:au/state:qld/slaed:qld228
 QLD229,Inala,Q5355525,2017/08/09,Legislative Assembly,country:au/state:qld,country:au/state:qld/slaed:qld229
-QLD230,Ipswich,Q5355531,2017/08/09,Legislative Assembly,country:au/state:qld,country:au/state:qld/slaed:qld230
+QLD230,Ipswich,Q5355530,2017/08/09,Legislative Assembly,country:au/state:qld,country:au/state:qld/slaed:qld230
 QLD231,Ipswich West,Q5355532,2017/08/09,Legislative Assembly,country:au/state:qld,country:au/state:qld/slaed:qld231
 QLD232,Jordan,Q30641922,2017/08/09,Legislative Assembly,country:au/state:qld,country:au/state:qld/slaed:qld232
 QLD233,Kawana,Q5355554,2017/08/09,Legislative Assembly,country:au/state:qld,country:au/state:qld/slaed:qld233
@@ -213,7 +213,7 @@ QLD282,Warrego,Q5356077,2017/08/09,Legislative Assembly,country:au/state:qld,cou
 QLD283,Waterford,Q5356085,2017/08/09,Legislative Assembly,country:au/state:qld,country:au/state:qld/slaed:qld283
 QLD284,Whitsunday,Q5356123,2017/08/09,Legislative Assembly,country:au/state:qld,country:au/state:qld/slaed:qld284
 QLD285,Woodridge,Q5356151,2017/08/09,Legislative Assembly,country:au/state:qld,country:au/state:qld/slaed:qld285
-QLD286,Burnett,Q5355186,2017/08/09,Legislative Assembly,country:au/state:qld,country:au/state:qld/slaed:qld286
+QLD286,Burnett,Q5355185,2017/08/09,Legislative Assembly,country:au/state:qld,country:au/state:qld/slaed:qld286
 QLD287,Noosa,Q5355786,2017/08/09,Legislative Assembly,country:au/state:qld,country:au/state:qld/slaed:qld287
 SA18500002,Mitchell,Q5355674,2015/05/11,Legislative Assembly,country:au/state:sa,country:au/state:sa/shaed:sa18500002
 SA18500003,Morphett,Q5355700,2015/05/11,Legislative Assembly,country:au/state:sa,country:au/state:sa/shaed:sa18500003
@@ -333,7 +333,7 @@ VIC278,Sandringham,Q5355926,2015/05/05,Legislative Assembly,country:au/state:vic
 VIC279,Clarinda,Q17002321,2015/05/05,Legislative Assembly,country:au/state:vic,country:au/state:vic/slaed:vic279
 VIC280,Brighton,Q5355150,2015/05/05,Legislative Assembly,country:au/state:vic,country:au/state:vic/slaed:vic280
 VIC281,Prahran,Q5355873,2015/05/05,Legislative Assembly,country:au/state:vic,country:au/state:vic/slaed:vic281
-VIC282,Richmond,Q1073994,2015/05/05,Legislative Assembly,country:au/state:vic,country:au/state:vic/slaed:vic282
+VIC282,Richmond,Q5355896,2015/05/05,Legislative Assembly,country:au/state:vic,country:au/state:vic/slaed:vic282
 VIC283,St Albans,Q5355970,2015/05/05,Legislative Assembly,country:au/state:vic,country:au/state:vic/slaed:vic283
 VIC284,Sydenham,Q17028255,2015/05/05,Legislative Assembly,country:au/state:vic,country:au/state:vic/slaed:vic284
 VIC285,Essendon,Q5355383,2015/05/05,Legislative Assembly,country:au/state:vic,country:au/state:vic/slaed:vic285
@@ -346,7 +346,7 @@ VIC291,Hawthorn,Q5355501,2015/05/05,Legislative Assembly,country:au/state:vic,co
 VIC292,Kew,Q5355563,2015/05/05,Legislative Assembly,country:au/state:vic,country:au/state:vic/slaed:vic292
 VIC293,Burwood,Q5355193,2015/05/05,Legislative Assembly,country:au/state:vic,country:au/state:vic/slaed:vic293
 VIC294,Box Hill,Q5355143,2015/05/05,Legislative Assembly,country:au/state:vic,country:au/state:vic/slaed:vic294
-VIC295,Mulgrave,Q5355729,2015/05/05,Legislative Assembly,country:au/state:vic,country:au/state:vic/slaed:vic295
+VIC295,Mulgrave,Q5355730,2015/05/05,Legislative Assembly,country:au/state:vic,country:au/state:vic/slaed:vic295
 VIC296,Rowville,Q17028172,2015/05/05,Legislative Assembly,country:au/state:vic,country:au/state:vic/slaed:vic296
 VIC297,Forest Hill,Q5355410,2015/05/05,Legislative Assembly,country:au/state:vic,country:au/state:vic/slaed:vic297
 VIC298,Ferntree Gully,Q5355393,2015/05/05,Legislative Assembly,country:au/state:vic,country:au/state:vic/slaed:vic298

--- a/build_output.txt
+++ b/build_output.txt
@@ -39,34 +39,6 @@ WARNING: the district Launceston (Q5356227) wasn't found in the boundary data fo
 WARNING: the district Murchison (Q5356235) wasn't found in the boundary data for position Member of the Tasmanian Legislative Council (Q19299542)
 WARNING: the district McIntyre (Q38251647) wasn't found in the boundary data for position Member of the Tasmanian Legislative Council (Q19299542)
 WARNING: Position Member of the New South Wales Legislative Council (Q18810377) not in boundary associated_wikidata_positions
-WARNING: the district Mulgrave (Q5355730) wasn't found in the boundary data for position Member of the Victorian Legislative Assembly (Q18534408)
-WARNING: the district Richmond (Q5355896) wasn't found in the boundary data for position Member of the Victorian Legislative Assembly (Q18534408)
-WARNING: Position member of the Australian Capital Territory Legislative Assembly (Q6814365) not in boundary associated_wikidata_positions
-WARNING: the district Brindabella (Q2973470) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Brindabella (Q2973470) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Yerrabi (Q26907959) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Ginninderra (Q2973614) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Ginninderra (Q2973614) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Ginninderra (Q2973614) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Murrumbidgee (Q26907990) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Yerrabi (Q26907959) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Yerrabi (Q26907959) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Murrumbidgee (Q26907990) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Kurrajong (Q26907714) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Kurrajong (Q26907714) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Yerrabi (Q26907959) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Brindabella (Q2973470) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Kurrajong (Q26907714) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Yerrabi (Q26907959) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Kurrajong (Q26907714) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Brindabella (Q2973470) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Murrumbidgee (Q26907990) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Murrumbidgee (Q26907990) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Murrumbidgee (Q26907990) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Brindabella (Q2973470) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Kurrajong (Q26907714) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Ginninderra (Q2973614) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
-WARNING: the district Ginninderra (Q2973614) wasn't found in the boundary data for position member of the Australian Capital Territory Legislative Assembly (Q6814365)
 WARNING: Position member of Waverley Municipal Council (Q56477508) not in boundary associated_wikidata_positions
 WARNING: Position member of Lane Cove Council (Q56477513) not in boundary associated_wikidata_positions
 WARNING: Position member of Woollahra Municipal Council (Q56477518) not in boundary associated_wikidata_positions
@@ -171,10 +143,6 @@ WARNING: Position member of Fremantle City Council (Q56477935) not in boundary a
 WARNING: Position member of Perth City Council (Q56477939) not in boundary associated_wikidata_positions
 WARNING: Position member of Kwinana City Council (Q56477943) not in boundary associated_wikidata_positions
 WARNING: Position member of Kalamunda City Council (Q56477948) not in boundary associated_wikidata_positions
-WARNING: the district Ipswich (Q5355530) wasn't found in the boundary data for position Member of the Queensland Legislative Assembly (Q18526194)
-WARNING: the district Ipswich (Q5355530) wasn't found in the boundary data for position Member of the Queensland Legislative Assembly (Q18526194)
-WARNING: the district Burnett (Q5355185) wasn't found in the boundary data for position Member of the Queensland Legislative Assembly (Q18526194)
-WARNING: the district Burnett (Q5355185) wasn't found in the boundary data for position Member of the Queensland Legislative Assembly (Q18526194)
 WARNING: the district Gibson (Q38250827) wasn't found in the boundary data for position Member of the South Australian House of Assembly (Q18220900)
 WARNING: the district Black (Q38250839) wasn't found in the boundary data for position Member of the South Australian House of Assembly (Q18220900)
 WARNING: the district Hartley (Q5355492) wasn't found in the boundary data for position Member of the South Australian House of Assembly (Q18220900)
@@ -211,30 +179,7 @@ WARNING: the district Eastern Metropolitan Region (Q5330290) wasn't found in the
 WARNING: the district Western Victoria Region (Q7988421) wasn't found in the boundary data for position Member of the Victorian Legislative Council (Q19185341)
 WARNING: the district Northern Victoria Region (Q7059112) wasn't found in the boundary data for position Member of the Victorian Legislative Council (Q19185341)
 WARNING: the district Southern Metropolitan Region (Q7570135) wasn't found in the boundary data for position Member of the Victorian Legislative Council (Q19185341)
-WARNING: Position member of the Northern Territory Legislative Assembly (Q26998278) not in boundary associated_wikidata_positions
-WARNING: the district Barkly (Q5356198) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Casuarina (Q5356204) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Sanderson (Q5356251) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Fong Lim (Q5356215) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Namatjira (Q5356237) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Brennan (Q5356202) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Arnhem (Q5356197) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Arafura (Q5356195) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Karama (Q5356224) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Braitling (Q5356201) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Katherine (Q5356225) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Port Darwin (Q5356246) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Nhulunbuy (Q5356241) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Stuart (Q5356252) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Drysdale (Q5356210) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Daly (Q5356206) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Spillett (Q26267294) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Fannie Bay (Q5356213) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Araluen (Q5356196) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
-WARNING: the district Blain (Q5356200) wasn't found in the boundary data for position member of the Northern Territory Legislative Assembly (Q26998278)
 WARNING: Position Lord Mayor of Adelaide (Q49031784) not in boundary associated_wikidata_positions
-WARNING: Position Lord Mayor of Brisbane (Q29467089) not in boundary associated_wikidata_positions
-WARNING: the district City of Brisbane (Q917682) wasn't found in the boundary data for position Lord Mayor of Brisbane (Q29467089)
 WARNING: Position Lord Mayor of Adelaide (Q49031784) not in boundary associated_wikidata_positions
 WARNING: the district City of Adelaide (Q1094063) wasn't found in the boundary data for position Lord Mayor of Adelaide (Q49031784)
 WARNING: the district City of Adelaide (Q1094063) wasn't found in the boundary data for position Lord Mayor of Adelaide (Q49031784)

--- a/executive/Q56477660/current/popolo-m17n.json
+++ b/executive/Q56477660/current/popolo-m17n.json
@@ -49,7 +49,75 @@
     }
   ],
   "areas": [
-
+    {
+      "id": "Q36074",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/state:qld"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q36074"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q132050"
+      ],
+      "type": {
+        "lang:en": "state of Australia"
+      },
+      "name": {
+        "lang:en": "Queensland"
+      },
+      "parent_id": "Q408"
+    },
+    {
+      "id": "Q408",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q408"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q319145"
+      ],
+      "type": {
+        "lang:en": "country"
+      },
+      "name": {
+        "lang:en": "Commonwealth of Australia"
+      },
+      "parent_id": null
+    },
+    {
+      "id": "Q917682",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/state:qld/lga:qld21"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q917682"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q29467089"
+      ],
+      "type": {
+        "lang:en": "local government area of Queensland"
+      },
+      "name": {
+        "lang:en": "City of Brisbane"
+      },
+      "parent_id": "Q36074"
+    }
   ],
   "memberships": [
     {

--- a/legislative/Q4386693/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q4386693/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -11449,29 +11449,6 @@
   ],
   "areas": [
     {
-      "id": "Q1073994",
-      "identifiers": [
-        {
-          "scheme": "MS_FB",
-          "identifier": "country:au/state:vic/slaed:vic282"
-        },
-        {
-          "scheme": "wikidata",
-          "identifier": "Q1073994"
-        }
-      ],
-      "associated_wikidata_positions": [
-        "Q18534408"
-      ],
-      "type": {
-        "lang:en": "electoral district of Victoria"
-      },
-      "name": {
-        "lang:en": "Richmond"
-      },
-      "parent_id": "Q36687"
-    },
-    {
       "id": "Q14935126",
       "identifiers": [
         {
@@ -12967,7 +12944,7 @@
       "parent_id": "Q36687"
     },
     {
-      "id": "Q5355729",
+      "id": "Q5355730",
       "identifiers": [
         {
           "scheme": "MS_FB",
@@ -12975,7 +12952,7 @@
         },
         {
           "scheme": "wikidata",
-          "identifier": "Q5355729"
+          "identifier": "Q5355730"
         }
       ],
       "associated_wikidata_positions": [
@@ -13216,6 +13193,29 @@
       },
       "name": {
         "lang:en": "Preston"
+      },
+      "parent_id": "Q36687"
+    },
+    {
+      "id": "Q5355896",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/state:vic/slaed:vic282"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5355896"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q18534408"
+      ],
+      "type": {
+        "lang:en": "electoral district of Victoria"
+      },
+      "name": {
+        "lang:en": "Richmond"
       },
       "parent_id": "Q36687"
     },

--- a/legislative/Q494915/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q494915/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -453,7 +453,167 @@
     }
   ],
   "areas": [
-
+    {
+      "id": "Q26907714",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:act/slaed:act10"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q26907714"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q6814365"
+      ],
+      "type": {
+        "lang:en": "electorate of the Australian Capital Territory"
+      },
+      "name": {
+        "lang:en": "Kurrajong"
+      },
+      "parent_id": "Q3258"
+    },
+    {
+      "id": "Q26907959",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:act/slaed:act9"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q26907959"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q6814365"
+      ],
+      "type": {
+        "lang:en": "electorate of the Australian Capital Territory"
+      },
+      "name": {
+        "lang:en": "Yerrabi"
+      },
+      "parent_id": "Q3258"
+    },
+    {
+      "id": "Q26907990",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:act/slaed:act8"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q26907990"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q6814365"
+      ],
+      "type": {
+        "lang:en": "electorate of the Australian Capital Territory"
+      },
+      "name": {
+        "lang:en": "Murrumbidgee"
+      },
+      "parent_id": "Q3258"
+    },
+    {
+      "id": "Q2973470",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:act/slaed:act7"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2973470"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q6814365"
+      ],
+      "type": {
+        "lang:en": "electorate of the Australian Capital Territory"
+      },
+      "name": {
+        "lang:en": "Brindabella"
+      },
+      "parent_id": "Q3258"
+    },
+    {
+      "id": "Q2973614",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:act/slaed:act11"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2973614"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q6814365"
+      ],
+      "type": {
+        "lang:en": "electorate of the Australian Capital Territory"
+      },
+      "name": {
+        "lang:en": "Ginninderra"
+      },
+      "parent_id": "Q3258"
+    },
+    {
+      "id": "Q3258",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:act"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3258"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q493649"
+      ],
+      "type": {
+        "lang:en": "territory of Australia"
+      },
+      "name": {
+        "lang:en": "Australian Capital Territory"
+      },
+      "parent_id": "Q408"
+    },
+    {
+      "id": "Q408",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q408"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q319145"
+      ],
+      "type": {
+        "lang:en": "country"
+      },
+      "name": {
+        "lang:en": "Commonwealth of Australia"
+      },
+      "parent_id": null
+    }
   ],
   "memberships": [
     {

--- a/legislative/Q6518214/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q6518214/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -10265,21 +10265,6 @@
     },
     {
       "name": {
-        "lang:en": "David Kempton"
-      },
-      "id": "Q5235920",
-      "identifiers": [
-        {
-          "scheme": "wikidata",
-          "identifier": "Q5235920"
-        }
-      ],
-      "links": [
-
-      ]
-    },
-    {
-      "name": {
         "lang:en": "Deb Frecklington"
       },
       "id": "Q5247768",
@@ -14265,29 +14250,6 @@
       "parent_id": "Q408"
     },
     {
-      "id": "Q36687",
-      "identifiers": [
-        {
-          "scheme": "MS_FB",
-          "identifier": "country:au/state:vic"
-        },
-        {
-          "scheme": "wikidata",
-          "identifier": "Q36687"
-        }
-      ],
-      "associated_wikidata_positions": [
-        "Q132050"
-      ],
-      "type": {
-        "lang:en": "state of Australia"
-      },
-      "name": {
-        "lang:en": "Victoria"
-      },
-      "parent_id": "Q408"
-    },
-    {
       "id": "Q408",
       "identifiers": [
         {
@@ -14541,7 +14503,7 @@
       "parent_id": "Q36074"
     },
     {
-      "id": "Q5355186",
+      "id": "Q5355185",
       "identifiers": [
         {
           "scheme": "MS_FB",
@@ -14549,7 +14511,7 @@
         },
         {
           "scheme": "wikidata",
-          "identifier": "Q5355186"
+          "identifier": "Q5355185"
         }
       ],
       "associated_wikidata_positions": [
@@ -15024,7 +14986,7 @@
       "parent_id": "Q36074"
     },
     {
-      "id": "Q5355531",
+      "id": "Q5355530",
       "identifiers": [
         {
           "scheme": "MS_FB",
@@ -15032,7 +14994,7 @@
         },
         {
           "scheme": "wikidata",
-          "identifier": "Q5355531"
+          "identifier": "Q5355530"
         }
       ],
       "associated_wikidata_positions": [
@@ -25086,19 +25048,6 @@
     {
       "id": "http://www.wikidata.org/entity/statement/Q5235263-7E7DCB04-2366-405B-9C7C-F51ECA3B8266",
       "person_id": "Q5235263",
-      "organization_id": "Q6518214",
-      "role_superclass_code": "Q486839",
-      "role_superclass": {
-        "lang:en": "member of parliament"
-      },
-      "role_code": "Q18526194",
-      "role": {
-        "lang:en": "Member of the Queensland Legislative Assembly"
-      }
-    },
-    {
-      "id": "http://www.wikidata.org/entity/statement/Q5235920-50E793B3-CCCC-47F5-BA3B-992659D7DEA4",
-      "person_id": "Q5235920",
       "organization_id": "Q6518214",
       "role_superclass_code": "Q486839",
       "role_superclass": {

--- a/legislative/Q6518214/2018-01-01-to-2018-12-31/query-results.json
+++ b/legislative/Q6518214/2018-01-01-to-2018-12-31/query-results.json
@@ -35390,56 +35390,6 @@
     }, {
       "statement" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q5235920-50E793B3-CCCC-47F5-BA3B-992659D7DEA4"
-      },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q486839"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "member of parliament"
-      },
-      "role" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q18526194"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Member of the Queensland Legislative Assembly"
-      },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5235920"
-      },
-      "name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "David Kempton"
-      },
-      "org" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6518214"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Legislative Assembly of Queensland"
-      },
-      "org_jurisdiction" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q36074"
-      },
-      "org_seat_count" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
-        "type" : "literal",
-        "value" : "93"
-      }
-    }, {
-      "statement" : {
-        "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q5247768-877E62A9-AA4E-4886-AABB-9F614540D969"
       },
       "role_superclass" : {

--- a/legislative/Q9390785/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q9390785/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -337,7 +337,627 @@
     }
   ],
   "areas": [
-
+    {
+      "id": "Q26267294",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000086"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q26267294"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Spillett"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q3235",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q3235"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q1072341"
+      ],
+      "type": {
+        "lang:en": "territory of Australia"
+      },
+      "name": {
+        "lang:en": "Northern Territory"
+      },
+      "parent_id": "Q408"
+    },
+    {
+      "id": "Q408",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q408"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q319145"
+      ],
+      "type": {
+        "lang:en": "country"
+      },
+      "name": {
+        "lang:en": "Commonwealth of Australia"
+      },
+      "parent_id": null
+    },
+    {
+      "id": "Q5356195",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000069"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356195"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Arafura"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356196",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000078"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356196"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Araluen"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356197",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000062"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356197"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Arnhem"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356198",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000080"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356198"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Barkly"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356200",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000075"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356200"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Blain"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356201",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000065"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356201"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Braitling"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356202",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000070"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356202"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Brennan"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356204",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000067"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356204"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Casuarina"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356206",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000073"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356206"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Daly"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356210",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000076"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356210"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Drysdale"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356213",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000077"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356213"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Fannie Bay"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356215",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000079"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356215"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Fong Lim"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356218",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000071"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356218"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Goyder"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356223",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000074"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356223"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Johnston"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356224",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000063"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356224"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Karama"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356225",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000064"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356225"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Katherine"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356237",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000068"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356237"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Namatjira"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356239",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000066"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356239"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Nelson"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356241",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000081"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356241"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Nhulunbuy"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356242",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000072"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356242"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Nightcliff"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356246",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000084"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356246"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Port Darwin"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356251",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000082"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356251"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Sanderson"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356252",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000083"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356252"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Stuart"
+      },
+      "parent_id": "Q3235"
+    },
+    {
+      "id": "Q5356258",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:au/territory:nt/slaed:nt1000085"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q5356258"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q26998278"
+      ],
+      "type": {
+        "lang:en": "electoral division of the Northern Territory"
+      },
+      "name": {
+        "lang:en": "Wanguri"
+      },
+      "parent_id": "Q3235"
+    }
   ],
   "memberships": [
     {


### PR DESCRIPTION
This takes b3879c2 and 7b307c8 from #10 and renames them. This is because they potentially confuse that pull request, and the state assembly constituencies PR is already merged.